### PR TITLE
Update apache_activemq_rce_cve_2023_46604.rb to ensure timeout

### DIFF
--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -78,9 +78,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    connect
+    res = nil
+    begin
+      ::Timeout.timeout(datastore['ConnectTimeout']) do
+        connect
 
-    res = sock.get_once
+        res = sock.get_once
+      end
+    rescue => e
+      print_error("Error: #{e.message}")
+      return CheckCode::Unknown
+    end
 
     disconnect
 

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -79,15 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = nil
-    begin
-      ::Timeout.timeout(datastore['ConnectTimeout']) do
-        connect
+    ::Timeout.timeout(datastore['ConnectTimeout']) do
+      connect
 
-        res = sock.get_once
-      end
-    rescue => e
-      print_error("Error: #{e.message}")
-      return CheckCode::Unknown
+      res = sock.get_once
     end
 
     disconnect


### PR DESCRIPTION
Add a timeout to eliminate the hang in the check method

This fix is to ensure that if all else fails, the check will timeout and allow progress to continue instead of hanging on a host that does not reply as expected. This addresses Issue #19036.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/misc/apache_activemq_rce_cve_2023_46604`
- [ ] Set RHOSTS and RPORT to host/port that is not responding as ActiveMQ should (e.g., it's down or its not ActiveMQ)
- [ ] `check`
- [ ] **Verify** that the check will eventually time out even if it does not receive an expected ActiveMQ response.
- [ ] **Verify** that the check does not hang on servers that fail to respond as expected.
